### PR TITLE
add block-len build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ rm repos/zig/build.zig
 Get-ChildItem -Path "repos/zig/test" build.zig -Recurse | Remove-Item
 zig build run -- repos/zls/zig-out/bin/zls[.exe] [mode]
 # example with 'markov input dir' arg
-zig build run -- ../zls/zig-out/bin/zls markov ../zig/test/behavior
+zig build run -Dblock-len=8 -- repos/zls/zig-out/bin/zls markov repos/zig/test/
 ```

--- a/build.zig
+++ b/build.zig
@@ -32,4 +32,15 @@ pub fn build(b: *std.build.Builder) void {
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&exe_tests.step);
+
+    const block_len = b.option(
+        u8,
+        "block-len",
+        "how many bytes to consider when predicting the next character.  " ++
+            "defaults to 8.  " ++
+            "note: this may affect performance.",
+    ) orelse 8;
+    const options = b.addOptions();
+    options.addOption(u8, "block_len", block_len);
+    exe.addOptions("build_options", options);
 }

--- a/src/modes/Markov.zig
+++ b/src/modes/Markov.zig
@@ -5,10 +5,11 @@ const tres = @import("../tres.zig");
 const utils = @import("../utils.zig");
 const markov = @import("../markov.zig");
 const Fuzzer = @import("../Fuzzer.zig");
+const build_options = @import("build_options");
 
 const Markov = @This();
 
-const MarkovModel = markov.Model(8, false);
+const MarkovModel = markov.Model(build_options.block_len, false);
 
 allocator: std.mem.Allocator,
 fuzzer: *Fuzzer,


### PR DESCRIPTION
this allows users to control the markov model's randomness by specifying
 block_len on the command line like this:
`$ zig build run -Dblock-len=6 -- ...`