### PR TITLE
cap log file size to Fuzzer.file_cap

### DIFF
--- a/script/killzls.sh
+++ b/script/killzls.sh
@@ -1,0 +1,5 @@
+pids=$(pidof zls)
+pidsarr=($pids)
+pid=${pidsarr[0]}
+echo "zls pids $pids killing first pid $pid"
+kill $pid

--- a/src/main.zig
+++ b/src/main.zig
@@ -142,7 +142,8 @@ fn usage(comptime message: []const u8, message_args: anytype) UsageError {
 }
 
 pub fn main() !void {
-    var allocator = std.heap.page_allocator;
+    var main_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const allocator = main_arena.allocator();
 
     var args = parseArgs(allocator, try loadEnv(allocator)) catch {
         std.os.exit(1);
@@ -169,28 +170,29 @@ pub fn main() !void {
         zig_version,
         zls_version,
     );
+    defer fuzzer.deinit();
     try fuzzer.initCycle();
-    var markov_arena = std.heap.ArenaAllocator.init(allocator);
-    defer markov_arena.deinit();
-    var markov = try Markov.init(markov_arena.allocator(), fuzzer);
+    var markov = try Markov.init(allocator, fuzzer);
     defer markov.deinit();
 
     try std.fs.cwd().makePath("saved_logs");
+    const principal_path = try std.fs.path.join(main_arena.allocator(), &.{ "staging", "markov", "principal.zig" });
 
     while (true) {
-        var arena = std.heap.ArenaAllocator.init(allocator);
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
 
         markov.fuzz(arena.allocator()) catch {
             std.log.info("Restarting fuzzer...", .{});
             markov.cycle = 0;
-            fuzzer.kill();
+            try fuzzer.kill();
 
             var buf: [512]u8 = undefined;
-            const sub = try std.fmt.bufPrint(&buf, "saved_logs/logs-{d}", .{std.time.milliTimestamp()});
-            try std.fs.cwd().rename("logs", sub);
+            const log_dir = try std.fmt.bufPrint(&buf, "saved_logs/logs-{d}", .{std.time.milliTimestamp()});
+            try std.fs.cwd().rename("logs", log_dir);
+            try std.fs.cwd().copyFile(principal_path, try std.fs.cwd().openDir(log_dir, .{}), "principal.zig", .{});
 
-            try fuzzer.reset(args.zls_path);
+            try fuzzer.reset();
             try fuzzer.initCycle();
             try markov.openPrincipal();
         };


### PR DESCRIPTION
this patch chages the way log files are written to. in order to cap their size and maintain good perf, we write to the files circularly while always writing an EOF marker afterward. then when a zls crash is found, the 3 log files are reordered, eliminating the EOF marker so that the reader doesn't have to scan for it.

notes:
* the stdout.log grows to double Fuzzer.file_cap for some reason
* when zls crashes, also copy staging/markov/principal.zig into saved_logs
* remove duplicate logic from Fuzzer.create by using Fuzzer.reset
* log a heartbeat every 1000 ticks to detect zls stalls
* add script/killzls.sh to quickly kill zls on linux
* add Fuzzer.log_buf - used while reordering logs
* rename
  * Fuzzer.std{in,out,err} => std..._file
  * Fuzzer.read_buf => stdout_buf
  * Fuzzer.write_buf => stdin_buf