### PR TITLE
cap log file size to Fuzzer.LogFile.file_cap

### DIFF
--- a/script/killzls.sh
+++ b/script/killzls.sh
@@ -1,0 +1,5 @@
+pids=$(pidof zls)
+pidsarr=($pids)
+pid=${pidsarr[0]}
+echo "zls pids $pids killing first pid $pid"
+kill $pid

--- a/src/Fuzzer.zig
+++ b/src/Fuzzer.zig
@@ -13,21 +13,76 @@ proc: ChildProcess,
 zig_version: []const u8,
 zls_version: []const u8,
 
-read_buf: std.ArrayListUnmanaged(u8),
-write_buf: std.ArrayListUnmanaged(u8),
-open_buf: std.ArrayListUnmanaged(u8),
+buf: std.ArrayListUnmanaged(u8) = .{},
 
 prng: std.rand.DefaultPrng,
 id: usize = 0,
 
-stdin: std.fs.File,
-stderr: std.fs.File,
-stdout: std.fs.File,
+stdin_file: LogFile,
+stdout_file: LogFile,
+stderr_file: LogFile,
 
 stderr_thread: std.Thread,
-// stdout_thread: std.Thread,
 
 args: Args,
+
+/// represents rotating log files
+pub const LogFile = struct {
+    files: [len]std.fs.File,
+    /// the index of the current file and name
+    idx: u8 = 0,
+    /// saved file names - used for cleanup and re-initialization
+    names: [len][]const u8,
+
+    pub const len = 2;
+    pub const file_cap = std.mem.page_size * 2;
+
+    /// init idx and names but leaves files undefined
+    pub fn init(comptime name_fmt: []const u8, allocator: std.mem.Allocator) !LogFile {
+        var result: LogFile = undefined;
+        result.idx = 0;
+        var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+
+        for (result.names) |*name, i| {
+            var buf2: [8]u8 = undefined;
+            const num = if (i == 0) "" else try std.fmt.bufPrint(&buf2, ".{}", .{i});
+            name.* = try allocator.dupe(u8, try std.fmt.bufPrint(&buf, name_fmt, .{num}));
+        }
+
+        return result;
+    }
+
+    /// create files using previously init names
+    pub fn createFiles(lf: *LogFile) !void {
+        for (lf.files) |*file, i|
+            file.* = try std.fs.cwd().createFile(lf.names[i], .{ .read = true, .truncate = true });
+    }
+    pub fn currentFile(lf: LogFile) std.fs.File {
+        return lf.files[lf.idx];
+    }
+    pub fn currentName(lf: LogFile) []const u8 {
+        return lf.names[lf.idx];
+    }
+    /// close all files
+    pub fn close(lf: *LogFile) void {
+        for (lf.files) |f| f.close();
+    }
+    pub fn nextIdx(idx: u8) u8 {
+        return (idx + 1) % len;
+    }
+
+    fn writeFile(lf: *LogFile, bytes: []const u8, debug: bool) !void {
+        _ = debug;
+        const file = lf.currentFile();
+        _ = try file.writeAll(bytes);
+        if (try file.getEndPos() > file_cap / LogFile.len) {
+            lf.idx = LogFile.nextIdx(lf.idx);
+            const file2 = lf.currentFile();
+            try file2.setEndPos(0);
+            try file2.seekTo(0);
+        }
+    }
+};
 
 pub const Mode = std.meta.Tag(Args.Base);
 
@@ -77,43 +132,24 @@ pub fn create(
     zig_version: []const u8,
     zls_version: []const u8,
 ) !*Fuzzer {
-    var fuzzer = try allocator.create(Fuzzer);
-
-    fuzzer.id = 0;
-    fuzzer.allocator = allocator;
-    fuzzer.args = args;
-
-    fuzzer.zig_version = zig_version;
-    fuzzer.zls_version = zls_version;
-
-    fuzzer.proc = std.ChildProcess.init(&.{ args.zls_path, "--enable-debug-log" }, allocator);
-
-    fuzzer.proc.stdin_behavior = .Pipe;
-    fuzzer.proc.stderr_behavior = .Pipe;
-
-    fuzzer.proc.stdout_behavior = .Pipe;
-
-    try fuzzer.proc.spawn();
-
-    try std.fs.cwd().makePath("logs");
-    fuzzer.stdin = try std.fs.cwd().createFile("logs/stdin.log", .{});
-    fuzzer.stderr = try std.fs.cwd().createFile("logs/stderr.log", .{});
-    fuzzer.stdout = try std.fs.cwd().createFile("logs/stdout.log", .{});
-
-    var info_buf: [512]u8 = undefined;
-    const sub_info_data = try std.fmt.bufPrint(&info_buf, "zig version: {s}\nzls version: {s}\n", .{ fuzzer.zig_version, fuzzer.zls_version });
-    try std.fs.cwd().writeFile("logs/info", sub_info_data);
-
-    fuzzer.stderr_thread = try std.Thread.spawn(.{}, readStderr, .{fuzzer});
-
     var seed: u64 = 0;
     try std.os.getrandom(std.mem.asBytes(&seed));
 
-    fuzzer.read_buf = .{};
-    fuzzer.write_buf = .{};
-    fuzzer.open_buf = .{};
-    fuzzer.prng = std.rand.DefaultPrng.init(seed);
+    var fuzzer = try allocator.create(Fuzzer);
 
+    fuzzer.* = .{
+        .allocator = allocator,
+        .args = args,
+        .zig_version = zig_version,
+        .zls_version = zls_version,
+        .stdin_file = try LogFile.init("logs/stdin{s}.log", allocator),
+        .stdout_file = try LogFile.init("logs/stdout{s}.log", allocator),
+        .stderr_file = try LogFile.init("logs/stderr{s}.log", allocator),
+        .stderr_thread = undefined,
+        .proc = undefined,
+        .prng = std.rand.DefaultPrng.init(seed),
+    };
+    try fuzzer.reset();
     return fuzzer;
 }
 
@@ -122,17 +158,16 @@ pub fn kill(fuzzer: *Fuzzer) void {
         std.log.err("{s}", .{@errorName(err)});
     };
 
-    fuzzer.stdin.close();
-    fuzzer.stderr.close();
-    fuzzer.stdout.close();
-
     fuzzer.stderr_thread.join();
+
+    // merge must be here after stderr_thread.join() to avoid race
+    fuzzer.mergeAndCloseLogs() catch unreachable;
 }
 
-pub fn reset(fuzzer: *Fuzzer, zls_path: []const u8) !void {
+pub fn reset(fuzzer: *Fuzzer) !void {
     fuzzer.id = 0;
 
-    fuzzer.proc = std.ChildProcess.init(&.{ zls_path, "--enable-debug-log" }, fuzzer.allocator);
+    fuzzer.proc = std.ChildProcess.init(&.{ fuzzer.args.zls_path, "--enable-debug-log" }, fuzzer.allocator);
 
     fuzzer.proc.stdin_behavior = .Pipe;
     fuzzer.proc.stderr_behavior = .Pipe;
@@ -141,9 +176,9 @@ pub fn reset(fuzzer: *Fuzzer, zls_path: []const u8) !void {
     try fuzzer.proc.spawn();
 
     try std.fs.cwd().makePath("logs");
-    fuzzer.stdin = try std.fs.cwd().createFile("logs/stdin.log", .{});
-    fuzzer.stderr = try std.fs.cwd().createFile("logs/stderr.log", .{});
-    fuzzer.stdout = try std.fs.cwd().createFile("logs/stdout.log", .{});
+    try fuzzer.stdin_file.createFiles();
+    try fuzzer.stdout_file.createFiles();
+    try fuzzer.stderr_file.createFiles();
 
     var info_buf: [512]u8 = undefined;
     const sub_info_data = try std.fmt.bufPrint(&info_buf, "zig version: {s}\nzls version: {s}\n", .{ fuzzer.zig_version, fuzzer.zls_version });
@@ -157,13 +192,11 @@ pub fn deinit(fuzzer: *Fuzzer) void {
         std.log.err("{s}", .{@errorName(err)});
     };
 
-    fuzzer.read_buf.deinit(fuzzer.allocator);
-    fuzzer.write_buf.deinit(fuzzer.allocator);
-    fuzzer.open_buf.deinit(fuzzer.allocator);
+    fuzzer.buf.deinit(fuzzer.allocator);
 
-    fuzzer.stdin.close();
-    fuzzer.stderr.close();
-    fuzzer.stdout.close();
+    fuzzer.stdin_file.close();
+    fuzzer.stderr_file.close();
+    fuzzer.stdout_file.close();
 
     fuzzer.stderr_thread.join();
 
@@ -171,14 +204,14 @@ pub fn deinit(fuzzer: *Fuzzer) void {
 }
 
 fn readStderr(fuzzer: *Fuzzer) void {
-    var lf = std.fifo.LinearFifo(u8, .{ .Static = std.mem.page_size }).init();
-
+    var buf: [std.mem.page_size]u8 = undefined;
     while (true) {
-        var stderr = fuzzer.proc.stderr orelse break;
-        lf.pump(stderr.reader(), fuzzer.stderr.writer()) catch break;
+        const stderr = fuzzer.proc.stderr orelse break;
+        const reader = stderr.reader();
+        const amt = reader.read(&buf) catch break;
+        fuzzer.stderr_file.writeFile(buf[0..amt], false) catch unreachable;
+        if (fuzzer.id % 1000 == 0) std.log.info("heartbeat {}", .{fuzzer.id});
     }
-
-    std.log.err("stderr failure", .{});
 }
 
 const RequestHeader = struct {
@@ -222,35 +255,77 @@ pub fn random(fuzzer: *Fuzzer) std.rand.Random {
 }
 
 pub fn writeJson(fuzzer: *Fuzzer, data: anytype) !void {
-    fuzzer.write_buf.items.len = 0;
+    fuzzer.buf.items.len = 0;
 
     try tres.stringify(
         data,
         .{ .emit_null_optional_fields = false },
-        fuzzer.write_buf.writer(fuzzer.allocator),
+        fuzzer.buf.writer(fuzzer.allocator),
     );
 
     var zls_stdin = fuzzer.proc.stdin.?.writer();
-    try zls_stdin.print("Content-Length: {d}\r\n\r\n", .{fuzzer.write_buf.items.len});
-    try zls_stdin.writeAll(fuzzer.write_buf.items);
+    try zls_stdin.print("Content-Length: {d}\r\n\r\n", .{fuzzer.buf.items.len});
+    try zls_stdin.writeAll(fuzzer.buf.items);
+    try fuzzer.buf.appendSlice(fuzzer.allocator, "\n\n");
 
-    try fuzzer.stdin.writeAll(fuzzer.write_buf.items);
-    try fuzzer.stdin.writeAll("\n\n");
+    try fuzzer.stdin_file.writeFile(fuzzer.buf.items, false);
 }
 
 pub fn readToBuffer(fuzzer: *Fuzzer) !void {
     const header = try fuzzer.readRequestHeader();
-    try fuzzer.read_buf.ensureTotalCapacity(fuzzer.allocator, header.content_length);
-    fuzzer.read_buf.items.len = header.content_length;
-    _ = try fuzzer.proc.stdout.?.reader().readAll(fuzzer.read_buf.items);
-
-    _ = try fuzzer.stdout.writeAll(fuzzer.read_buf.items);
-    _ = try fuzzer.stdout.writeAll("\n");
+    try fuzzer.buf.ensureTotalCapacity(fuzzer.allocator, header.content_length + 1);
+    fuzzer.buf.items.len = header.content_length;
+    _ = try fuzzer.proc.stdout.?.reader().readAll(fuzzer.buf.items);
+    fuzzer.buf.items.len += 1;
+    fuzzer.buf.items[fuzzer.buf.items.len - 1] = '\n';
+    try fuzzer.stdout_file.writeFile(fuzzer.buf.items, true);
 }
 
 pub fn readAndPrint(fuzzer: *Fuzzer) !void {
     try fuzzer.readToBuffer();
-    std.log.info("{s}", .{fuzzer.read_buf.items});
+    std.log.info("{s}", .{fuzzer.buf.items});
+}
+
+/// copy contents from rotated log files into single file in correct order.
+/// also rename the file so that names are always consistent
+/// (ie stderr.1.log -> stderr.log).
+fn mergeAndCloseLogs(fuzzer: *Fuzzer) !void {
+    try fuzzer.mergeAndCloseLog(fuzzer.stdin_file);
+    try fuzzer.mergeAndCloseLog(fuzzer.stdout_file);
+    try fuzzer.mergeAndCloseLog(fuzzer.stderr_file);
+}
+
+fn mergeAndCloseLog(fuzzer: *Fuzzer, log_file: LogFile) !void {
+    fuzzer.buf.items.len = 0;
+    const startidx = log_file.idx;
+    // start with the 'oldest' idx, stop at current
+    var idx = LogFile.nextIdx(log_file.idx);
+    while (true) : (idx = LogFile.nextIdx(idx)) {
+        const file = log_file.files[idx];
+        const buf_start = fuzzer.buf.items.len;
+        const file_size = try file.getEndPos();
+        try fuzzer.buf.ensureUnusedCapacity(fuzzer.allocator, file_size);
+        fuzzer.buf.items.len += file_size;
+        try file.seekTo(0);
+        const amt = try file.readAll(fuzzer.buf.items[buf_start..fuzzer.buf.items.len]);
+        std.debug.assert(amt == file_size);
+        if (idx == startidx)
+            break;
+        // done with this 'old' file. close and delete it.
+        file.close();
+        try std.fs.cwd().deleteFile(log_file.names[idx]);
+    }
+    // write captured contents to current file
+    const file = log_file.currentFile();
+    try file.setEndPos(0);
+    try file.seekTo(0);
+    _ = try file.write(fuzzer.buf.items);
+    file.close();
+    // rename the log file if necessary
+    // not necessary if idx == 0 (same name in this case)
+    if (log_file.idx != 0) {
+        try std.fs.cwd().rename(log_file.currentName(), log_file.names[0]);
+    }
 }
 
 pub fn readUntilLastResponse(fuzzer: *Fuzzer, arena: std.mem.Allocator) !void {
@@ -258,7 +333,7 @@ pub fn readUntilLastResponse(fuzzer: *Fuzzer, arena: std.mem.Allocator) !void {
         try fuzzer.readToBuffer();
 
         var tree = std.json.Parser.init(arena, true);
-        const vt = try tree.parse(fuzzer.read_buf.items);
+        const vt = try tree.parse(fuzzer.buf.items);
 
         if (vt.root.Object.get("method") != null) continue;
         if (vt.root.Object.get("id") != null) break;


### PR DESCRIPTION
this patch chages the way log files are written to. in order to cap their size, we rotate the log files when they grow beyond the cap. then when a zls crash is found the rotated log files are merged in order and renamed if necessary before moving into the saved_logs folder.

notes:
* add Fuzzer.LogFile which represents a rotating log file
* when zls crashes, also copy staging/markov/principal.zig into saved_logs
* remove duplicate logic from Fuzzer.create by using Fuzzer.reset
* log a heartbeat every 1000 ticks to detect zls stalls
* add script/killzls.sh to quickly kill zls on linux
* rename Fuzzer.std{in,out,err} => std..._file
* replace Fuzzer.{read,write}_buf with Fuzzer.buf