### PR TITLE
`std.sort.sort` -> `std.mem.sort`

### DIFF
--- a/src/markov.zig
+++ b/src/markov.zig
@@ -113,7 +113,7 @@ pub fn Model(comptime byte_len: comptime_int, comptime debug: bool) type {
         pub fn prep(self: *Self) void {
             // sort each follow map by frequency descending so that more frequent come first
             for (self.table.values()) |follows|
-                std.sort.sort(Follows.Item, follows.map.items, {}, Follows.lessThanByCount);
+                std.mem.sort(Follows.Item, follows.map.items, {}, Follows.lessThanByCount);
         }
 
         pub const GenOptions = struct {


### PR DESCRIPTION
Looks like I, unwittingly, tasked myself with this one :grinning: 